### PR TITLE
Allow choosing camera or photo library on mobile photo uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,7 +508,7 @@
           <button id="thenNowBtn" class="ghost tiny">Then vs Now</button>
           <label class="ghost tiny" style="display:inline-flex;align-items:center;gap:4px;cursor:pointer;border:1px solid var(--line2);border-radius:8px;padding:5px 10px;background:transparent;color:var(--ink);font-size:12px">
             + Add
-            <input type="file" id="photoUploadInput" accept="image/*,.heic,.heif" capture="environment" multiple style="display:none">
+            <input type="file" id="photoUploadInput" accept="image/*,.heic,.heif" multiple style="display:none">
           </label>
         </div>
       </div>


### PR DESCRIPTION
## Summary
On mobile, tapping "Add" to upload a plant photo opened the rear camera directly and gave no way to select an existing photo from the library. The cause was `capture="environment"` on the file input — that attribute forces the camera and bypasses the native picker.

## Change
- Removed `capture="environment"` from `#photoUploadInput`. The input still has `accept="image/*,.heic,.heif"` and `multiple`, so users now get the standard iOS/Android picker with Camera, Photo Library, and Files as options.

## Test plan
- [ ] On iOS Safari: tap "Add" on a plant card → confirm picker shows "Photo Library", "Take Photo", "Choose Files"
- [ ] On Android Chrome: tap "Add" → confirm picker shows Camera and Gallery options
- [ ] On desktop: tap "Add" → file dialog still opens normally
- [ ] Multi-select still works (pick 2+ photos in one go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)