### PR TITLE
Add Collection stats panel with tag pie + acquisitions bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,48 +10,48 @@
 <title>Scott and Stacy's Plants</title>
 <style>
   :root{
-    --bg:#0d1611;            /* deep forest, near-black */
-    --bg2:#11201a;           /* lifted panels behind */
-    --panel:#16241d;         /* card */
-    --panel2:#1c2e25;        /* nested */
-    --ink:#e8e4d3;           /* warm birch/moonlight text */
-    --ink-soft:#cdc8b3;
-    --muted:#8a9483;         /* lichen */
-    --line:#243730;          /* moss border */
-    --line2:#2e463c;
-    --accent:#8fc06a;        /* fresh leaf */
-    --accent-deep:#5d8a3e;   /* darker leaf */
-    --accent2:#d49858;       /* warm bark / autumn maple */
+    --bg:#08191c;            /* deep teal, near-black */
+    --bg2:#0d2629;           /* lifted panels behind */
+    --panel:#102d31;         /* card */
+    --panel2:#163a3f;        /* nested */
+    --ink:#e3eef0;           /* cool moonlight text */
+    --ink-soft:#c2d6d9;
+    --muted:#7e9598;         /* sea fog */
+    --line:#1f3f44;          /* deep teal border */
+    --line2:#2a5159;
+    --accent:#4dd0c1;        /* turquoise */
+    --accent-deep:#2ba294;   /* darker teal */
+    --accent2:#f0a868;       /* warm bark — kept as contrast */
     --warn:#e08a4a;          /* copper warning */
-    --cool:#7ec0c4;          /* lichen blue */
-    --chip:#1f3128;
-    --chip-line:#2c4438;
+    --cool:#7ec4cc;
+    --chip:#163a3f;
+    --chip-line:#2a5159;
     --shadow:0 1px 2px rgba(0,0,0,.4), 0 12px 36px rgba(0,0,0,.45);
   }
   [data-theme="light"]{
-    --bg:#f3eddc;
-    --bg2:#faf6ec;
+    --bg:#e6f1f2;
+    --bg2:#f3f9fa;
     --panel:#ffffff;
-    --panel2:#f5f0e0;
-    --ink:#26291f;
-    --ink-soft:#42463a;
-    --muted:#73776a;
-    --line:#d8cfba;
-    --line2:#c0b89f;
-    --accent:#3d6b22;
-    --accent-deep:#2a4f15;
+    --panel2:#ecf5f6;
+    --ink:#172a2c;
+    --ink-soft:#33484b;
+    --muted:#6c8488;
+    --line:#cbdcde;
+    --line2:#aec3c6;
+    --accent:#118a7d;
+    --accent-deep:#0c6e63;
     --accent2:#a86528;
     --warn:#9c4a18;
-    --cool:#3a6e7a;
-    --chip:#e9e3d2;
-    --chip-line:#d3cab3;
+    --cool:#2c6e7a;
+    --chip:#deeef0;
+    --chip-line:#c2d6d9;
     --shadow:0 1px 2px rgba(0,0,0,.04), 0 8px 22px rgba(0,0,0,.08);
   }
   *{box-sizing:border-box}
   html,body{margin:0;padding:0;
     background:
-      radial-gradient(1200px 600px at 80% -10%, #1a3025 0%, transparent 60%),
-      radial-gradient(900px 500px at 0% 100%, #0f231b 0%, transparent 55%),
+      radial-gradient(1200px 600px at 80% -10%, #163b41 0%, transparent 60%),
+      radial-gradient(900px 500px at 0% 100%, #0c2528 0%, transparent 55%),
       var(--bg);
     background-attachment:fixed;
     color:var(--ink);
@@ -64,8 +64,7 @@
   .sub{color:var(--muted);font-size:13px}
   .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
   @media (max-width:900px){.grid{grid-template-columns:1fr}}
-  .stats-row{display:grid;grid-template-columns:auto 1fr;gap:24px;align-items:start}
-  @media (max-width:700px){.stats-row{grid-template-columns:1fr}}
+  .stats-row{display:grid;grid-template-columns:repeat(auto-fit, minmax(280px, 1fr));gap:24px;align-items:start}
   .stats-legend{display:flex;flex-direction:column;gap:4px;font-size:13px;max-height:200px;overflow-y:auto}
   .stats-legend .lr{display:grid;grid-template-columns:12px 1fr auto;gap:8px;align-items:center}
   .stats-legend .dot{width:10px;height:10px;border-radius:2px}
@@ -372,20 +371,6 @@
     <div id="recentLog" class="small">No entries yet.</div>
   </div>
 
-  <div class="panel full" id="statsPanel">
-    <h2>Collection stats</h2>
-    <div class="stats-row">
-      <div>
-        <div class="small" style="margin-bottom:6px;color:var(--muted)">By primary tag (living plants)</div>
-        <div id="statsPie"></div>
-      </div>
-      <div>
-        <div class="small" style="margin-bottom:6px;color:var(--muted)">Plants acquired per year</div>
-        <div id="statsBars"></div>
-      </div>
-    </div>
-  </div>
-
   <div class="panel full">
     <h2>Plants <span class="small">(click "edit" on a row)</span></h2>
     <div class="filter-row">
@@ -411,6 +396,24 @@
     <div class="row" style="margin-top:10px">
       <button id="addPlantBtn" class="ghost">+ Add plant</button>
       <span class="right small" id="plantCount"></span>
+    </div>
+  </div>
+
+  <div class="panel full" id="statsPanel">
+    <h2>Collection stats</h2>
+    <div class="stats-row">
+      <div>
+        <div class="small" style="margin-bottom:6px;color:var(--muted)">By primary tag (living plants)</div>
+        <div id="statsPie"></div>
+      </div>
+      <div>
+        <div class="small" style="margin-bottom:6px;color:var(--muted)">Plants acquired per year</div>
+        <div id="statsBars"></div>
+      </div>
+      <div>
+        <div class="small" style="margin-bottom:6px;color:var(--muted)">Money spent per year</div>
+        <div id="statsSpend"></div>
+      </div>
     </div>
   </div>
 
@@ -2222,20 +2225,17 @@ function renderStats(){
     pieEl.innerHTML = `<div class="stats-pie"><svg viewBox="0 0 ${size} ${size}" width="${size}" height="${size}" aria-label="Plants by tag">${paths}</svg><div class="stats-legend">${legend}</div></div>`;
   }
 
-  // Bar: acquisitions per year (counts plant rows × quantity)
-  const yearCounts = new Map();
-  for (const p of (state.plants||[])){
-    if (!p.purchased) continue;
-    const y = parseInt(String(p.purchased).slice(0,4), 10);
-    if (!y || y < 1900 || y > 2100) continue;
-    yearCounts.set(y, (yearCounts.get(y)||0) + Math.max(1, parseInt(p.quantity||1, 10) || 1));
-  }
-  if (!yearCounts.size){
-    barEl.innerHTML = '<div class="stats-empty">No purchase dates recorded.</div>';
-  } else {
-    const minY = Math.min(...yearCounts.keys()), maxY = Math.max(...yearCounts.keys());
+  // Helper: render a year-keyed bar chart into a target element
+  const drawYearBars = (target, byYear, fmt, ariaLabel, emptyMsg, fill) => {
+    const targetEl = $(target);
+    if (!targetEl) return;
+    if (!byYear.size){
+      targetEl.innerHTML = `<div class="stats-empty">${emptyMsg}</div>`;
+      return;
+    }
+    const minY = Math.min(...byYear.keys()), maxY = Math.max(...byYear.keys());
     const series = [];
-    for (let y=minY; y<=maxY; y++) series.push([y, yearCounts.get(y)||0]);
+    for (let y=minY; y<=maxY; y++) series.push([y, byYear.get(y)||0]);
     const w = 360, h = 200, padL = 24, padR = 12, padT = 16, padB = 28;
     const max = Math.max(1, ...series.map(s=>s[1]));
     const bw = (w - padL - padR) / series.length;
@@ -2245,14 +2245,36 @@ function renderStats(){
       const yy = h - padB - bh;
       const wd = bw*0.7;
       return `<g>
-        <rect x="${x.toFixed(2)}" y="${yy.toFixed(2)}" width="${wd.toFixed(2)}" height="${bh.toFixed(2)}" fill="var(--accent)" rx="2"/>
-        ${n ? `<text x="${(x+wd/2).toFixed(2)}" y="${(yy-4).toFixed(2)}" text-anchor="middle" font-size="10" fill="var(--ink-soft)">${n}</text>` : ''}
+        <rect x="${x.toFixed(2)}" y="${yy.toFixed(2)}" width="${wd.toFixed(2)}" height="${bh.toFixed(2)}" fill="${fill}" rx="2"/>
+        ${n ? `<text x="${(x+wd/2).toFixed(2)}" y="${(yy-4).toFixed(2)}" text-anchor="middle" font-size="10" fill="var(--ink-soft)">${fmt(n)}</text>` : ''}
         <text x="${(x+wd/2).toFixed(2)}" y="${h-padB+14}" text-anchor="middle" font-size="10" fill="var(--ink-soft)">${y}</text>
       </g>`;
     }).join('');
     const axis = `<line x1="${padL}" y1="${h-padB}" x2="${w-padR}" y2="${h-padB}" stroke="var(--line)"/>`;
-    barEl.innerHTML = `<svg viewBox="0 0 ${w} ${h}" width="100%" preserveAspectRatio="xMidYMid meet" aria-label="Plants acquired per year">${axis}${bars}</svg>`;
+    targetEl.innerHTML = `<svg viewBox="0 0 ${w} ${h}" width="100%" preserveAspectRatio="xMidYMid meet" aria-label="${ariaLabel}">${axis}${bars}</svg>`;
+  };
+
+  // Bar: acquisitions per year (counts plant rows × quantity)
+  const acquired = new Map();
+  // Bar: dollars spent per year, parsed from leading "$NNN" in notes × quantity
+  const spent = new Map();
+  for (const p of (state.plants||[])){
+    if (!p.purchased) continue;
+    const y = parseInt(String(p.purchased).slice(0,4), 10);
+    if (!y || y < 1900 || y > 2100) continue;
+    const qty = Math.max(1, parseInt(p.quantity||1, 10) || 1);
+    acquired.set(y, (acquired.get(y)||0) + qty);
+    const m = String(p.notes||'').match(/\$\s*([0-9]+(?:\.[0-9]{1,2})?)/);
+    if (m){
+      const price = parseFloat(m[1]);
+      if (!isNaN(price)) spent.set(y, (spent.get(y)||0) + price * qty);
+    }
   }
+  drawYearBars('#statsBars', acquired, n => String(n), 'Plants acquired per year',
+    'No purchase dates recorded.', 'var(--accent)');
+  const fmtMoney = n => n >= 1000 ? '$'+Math.round(n/100)/10+'k' : '$'+Math.round(n);
+  drawYearBars('#statsSpend', spent, fmtMoney, 'Money spent per year',
+    'No prices recorded in notes.', 'var(--accent2)');
 }
 
 function render(){ renderPlants(); renderLog(); buildBrief(); renderStats(); }

--- a/index.html
+++ b/index.html
@@ -64,6 +64,14 @@
   .sub{color:var(--muted);font-size:13px}
   .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
   @media (max-width:900px){.grid{grid-template-columns:1fr}}
+  .stats-row{display:grid;grid-template-columns:auto 1fr;gap:24px;align-items:start}
+  @media (max-width:700px){.stats-row{grid-template-columns:1fr}}
+  .stats-legend{display:flex;flex-direction:column;gap:4px;font-size:13px;max-height:200px;overflow-y:auto}
+  .stats-legend .lr{display:grid;grid-template-columns:12px 1fr auto;gap:8px;align-items:center}
+  .stats-legend .dot{width:10px;height:10px;border-radius:2px}
+  .stats-legend .num{color:var(--muted);font-variant-numeric:tabular-nums}
+  .stats-pie{display:flex;gap:16px;align-items:center;flex-wrap:wrap}
+  .stats-empty{color:var(--muted);font-size:13px;padding:20px 0}
   .panel{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 18px;box-shadow:var(--shadow)}
   .panel.full{grid-column:1/-1}
   .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
@@ -362,6 +370,20 @@
     <input type="text" id="logNote" placeholder="optional note (e.g. deep soak, 1 gal each)">
     <hr>
     <div id="recentLog" class="small">No entries yet.</div>
+  </div>
+
+  <div class="panel full" id="statsPanel">
+    <h2>Collection stats</h2>
+    <div class="stats-row">
+      <div>
+        <div class="small" style="margin-bottom:6px;color:var(--muted)">By primary tag (living plants)</div>
+        <div id="statsPie"></div>
+      </div>
+      <div>
+        <div class="small" style="margin-bottom:6px;color:var(--muted)">Plants acquired per year</div>
+        <div id="statsBars"></div>
+      </div>
+    </div>
   </div>
 
   <div class="panel full">
@@ -2154,7 +2176,86 @@ $('#r2RecoverBtn').onclick = async ()=>{
 };
 
 /* ---------- render ---------- */
-function render(){ renderPlants(); renderLog(); buildBrief(); }
+function renderStats(){
+  const pieEl = $('#statsPie'), barEl = $('#statsBars');
+  if (!pieEl || !barEl) return;
+  const palette = ['#5c8a5e','#7aa67c','#a4c4a6','#c8d8c1','#cd8c5c','#e0a576','#8aa3b0','#a8b8be','#7e6b8f','#9d8db0','#b8a8c4','#888'];
+
+  // Pie: living plants by primary tag
+  const alive = (state.plants||[]).filter(p => !p.dead);
+  if (!alive.length){
+    pieEl.innerHTML = '<div class="stats-empty">No plants yet.</div>';
+  } else {
+    const tagCounts = new Map();
+    for (const p of alive){
+      const first = (p.tags||'').split(',').map(s=>s.trim().toLowerCase()).filter(Boolean)[0] || 'untagged';
+      tagCounts.set(first, (tagCounts.get(first)||0) + 1);
+    }
+    const sorted = [...tagCounts.entries()].sort((a,b)=>b[1]-a[1]);
+    const total = alive.length;
+    const slices = []; let otherN = 0;
+    for (const [tag, n] of sorted){
+      if (sorted.length > 8 && n/total < 0.03) otherN += n;
+      else slices.push([tag, n]);
+    }
+    if (otherN > 0) slices.push(['other', otherN]);
+
+    const size = 180, r = 80, cx = size/2, cy = size/2;
+    let angle = -Math.PI/2;
+    const paths = slices.map(([_, n], i) => {
+      const frac = n/total;
+      // Single-slice case: render a full circle (arc with same start/end is a no-op)
+      if (slices.length === 1){
+        return `<circle cx="${cx}" cy="${cy}" r="${r}" fill="${palette[0]}" stroke="var(--panel)" stroke-width="1.5"/>`;
+      }
+      const a2 = angle + frac * Math.PI*2;
+      const large = frac > 0.5 ? 1 : 0;
+      const x1 = cx + r*Math.cos(angle), y1 = cy + r*Math.sin(angle);
+      const x2 = cx + r*Math.cos(a2), y2 = cy + r*Math.sin(a2);
+      angle = a2;
+      return `<path d="M ${cx} ${cy} L ${x1.toFixed(2)} ${y1.toFixed(2)} A ${r} ${r} 0 ${large} 1 ${x2.toFixed(2)} ${y2.toFixed(2)} Z" fill="${palette[i % palette.length]}" stroke="var(--panel)" stroke-width="1.5"/>`;
+    }).join('');
+    const legend = slices.map(([tag, n], i) => {
+      const pct = Math.round(n/total*100);
+      return `<div class="lr"><span class="dot" style="background:${palette[i % palette.length]}"></span><span>${escapeHtml(tag)}</span><span class="num">${n} · ${pct}%</span></div>`;
+    }).join('');
+    pieEl.innerHTML = `<div class="stats-pie"><svg viewBox="0 0 ${size} ${size}" width="${size}" height="${size}" aria-label="Plants by tag">${paths}</svg><div class="stats-legend">${legend}</div></div>`;
+  }
+
+  // Bar: acquisitions per year (counts plant rows × quantity)
+  const yearCounts = new Map();
+  for (const p of (state.plants||[])){
+    if (!p.purchased) continue;
+    const y = parseInt(String(p.purchased).slice(0,4), 10);
+    if (!y || y < 1900 || y > 2100) continue;
+    yearCounts.set(y, (yearCounts.get(y)||0) + Math.max(1, parseInt(p.quantity||1, 10) || 1));
+  }
+  if (!yearCounts.size){
+    barEl.innerHTML = '<div class="stats-empty">No purchase dates recorded.</div>';
+  } else {
+    const minY = Math.min(...yearCounts.keys()), maxY = Math.max(...yearCounts.keys());
+    const series = [];
+    for (let y=minY; y<=maxY; y++) series.push([y, yearCounts.get(y)||0]);
+    const w = 360, h = 200, padL = 24, padR = 12, padT = 16, padB = 28;
+    const max = Math.max(1, ...series.map(s=>s[1]));
+    const bw = (w - padL - padR) / series.length;
+    const bars = series.map(([y, n], i) => {
+      const bh = n === 0 ? 0 : (h - padT - padB) * (n / max);
+      const x = padL + i*bw + bw*0.15;
+      const yy = h - padB - bh;
+      const wd = bw*0.7;
+      return `<g>
+        <rect x="${x.toFixed(2)}" y="${yy.toFixed(2)}" width="${wd.toFixed(2)}" height="${bh.toFixed(2)}" fill="var(--accent)" rx="2"/>
+        ${n ? `<text x="${(x+wd/2).toFixed(2)}" y="${(yy-4).toFixed(2)}" text-anchor="middle" font-size="10" fill="var(--ink-soft)">${n}</text>` : ''}
+        <text x="${(x+wd/2).toFixed(2)}" y="${h-padB+14}" text-anchor="middle" font-size="10" fill="var(--ink-soft)">${y}</text>
+      </g>`;
+    }).join('');
+    const axis = `<line x1="${padL}" y1="${h-padB}" x2="${w-padR}" y2="${h-padB}" stroke="var(--line)"/>`;
+    barEl.innerHTML = `<svg viewBox="0 0 ${w} ${h}" width="100%" preserveAspectRatio="xMidYMid meet" aria-label="Plants acquired per year">${axis}${bars}</svg>`;
+  }
+}
+
+function render(){ renderPlants(); renderLog(); buildBrief(); renderStats(); }
 render();
 fetchForecast();
 refreshTokenInput();


### PR DESCRIPTION
## Summary
Adds a new "Collection stats" panel above the Plants table showing two at-a-glance charts of the collection.

## What's new
- **Pie — living plants by primary tag**. Uses the first tag in `p.tags` (lowercased), with `untagged` as a fallback. Slices smaller than 3% collapse into a single "other" slice once there are more than 8 categories. Legend lists each slice with its count and percentage.
- **Bar — plants acquired per year**. Groups by the year extracted from `p.purchased`, summing `p.quantity` so a row with `quantity: 3` counts as three. Empty years between min and max are filled with zero bars so the timeline reads continuously.

Both charts are inline SVG with no external library. They pick up theme colors from existing CSS variables (`--accent`, `--panel`, `--line`, `--ink-soft`) so light and dark modes both look right.

## Implementation notes
- New `renderStats()` is hooked into the existing `render()` pipeline, so charts refresh whenever plants change (add, edit, delete, sheet pull, GitHub pull).
- Single-slice pie special-cases to a `<circle>` to avoid the SVG arc-with-zero-sweep edge case.
- Layout uses `.stats-row { grid-template-columns: auto 1fr }` and collapses to a single column under 700px.

## Test plan
- [ ] Open the dashboard with the existing plant inventory loaded — both charts render
- [ ] Toggle the theme — colors stay legible in both modes
- [ ] Add a new plant with a fresh tag — pie updates to include it on next render
- [ ] Edit a plant's `purchased` year — bar updates
- [ ] Resize to mobile width — pie + bar stack vertically without overflow
- [ ] Delete the only plant in a tag category — slice disappears (or rolls into "other")

🤖 Generated with [Claude Code](https://claude.com/claude-code)