### PR TITLE
Gallery: 3:2 desktop ratio + plant/date filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,8 +66,9 @@
   @media (max-width:900px){.grid{grid-template-columns:1fr}}
   .stats-row{display:grid;grid-template-columns:repeat(auto-fit, minmax(280px, 1fr));gap:24px;align-items:start}
   .gallery{margin-bottom:16px;border-radius:14px;overflow:hidden;box-shadow:var(--shadow);border:1px solid var(--line);background:#000}
-  .gallery-stage{position:relative;width:100%;aspect-ratio:21/9;background:#0a0a0a}
-  @media (max-width:700px){.gallery-stage{aspect-ratio:4/3}}
+  .gallery-stage{position:relative;width:100%;aspect-ratio:3/2;background:#0a0a0a;max-height:560px}
+  @media (max-width:700px){.gallery-stage{aspect-ratio:4/3;max-height:none}}
+  .gallery-empty{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:#bbb;font-size:13px;text-align:center;padding:0 20px}
   .gallery-img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity .9s ease;cursor:pointer}
   .gallery-img.is-current{opacity:1}
   .gallery-caption{position:absolute;left:0;right:0;bottom:0;padding:14px 16px 12px;color:#fff;font-size:13px;
@@ -75,6 +76,17 @@
   .gallery-caption .gname{font-weight:600;font-size:15px;display:block;letter-spacing:-.01em}
   .gallery-caption .gmeta{opacity:.85;font-size:12px}
   .gallery-dots{position:absolute;top:10px;right:12px;display:flex;gap:4px;background:rgba(0,0,0,.45);padding:5px 9px;border-radius:999px;color:#fff;font-size:11px;font-variant-numeric:tabular-nums}
+  .gallery-filter-btn{position:absolute;top:10px;left:12px;background:rgba(0,0,0,.45);color:#fff;border:1px solid rgba(255,255,255,.15);
+    border-radius:999px;padding:5px 11px;font-size:11px;cursor:pointer;display:flex;align-items:center;gap:5px}
+  .gallery-filter-btn.is-active{background:var(--accent);color:#06201d;border-color:transparent}
+  .gallery-filter-pop{position:absolute;top:42px;left:12px;background:var(--panel);border:1px solid var(--line);border-radius:10px;
+    padding:12px 14px;box-shadow:var(--shadow);z-index:5;min-width:240px;max-width:calc(100% - 24px);display:none}
+  .gallery-filter-pop.is-open{display:block}
+  .gallery-filter-pop label{display:block;font-size:11px;color:var(--muted);margin-bottom:4px;text-transform:uppercase;letter-spacing:.06em}
+  .gallery-filter-pop select,.gallery-filter-pop input[type=date]{width:100%;background:var(--panel2);color:var(--ink);border:1px solid var(--line);
+    border-radius:6px;padding:6px 8px;font-size:13px;margin-bottom:10px;color-scheme:dark light}
+  .gallery-filter-pop .gfp-row{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+  .gallery-filter-pop .gfp-actions{display:flex;gap:6px;justify-content:space-between;margin-top:4px}
   .gallery-nav{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.4);border:1px solid rgba(255,255,255,.15);
     color:#fff;width:36px;height:36px;border-radius:50%;font-size:22px;line-height:1;cursor:pointer;opacity:0;transition:opacity .2s;
     display:flex;align-items:center;justify-content:center;padding:0}
@@ -358,8 +370,28 @@
     <img class="gallery-img" id="galleryImgB" alt="">
     <div class="gallery-caption" id="galleryCaption"></div>
     <div class="gallery-dots" id="galleryDots"></div>
+    <button class="gallery-filter-btn" id="galleryFilterBtn" aria-haspopup="true" aria-expanded="false">⚲ filter</button>
+    <div class="gallery-filter-pop" id="galleryFilterPop" role="dialog" aria-label="Gallery filters">
+      <label for="galleryFilterPlant">Plant</label>
+      <select id="galleryFilterPlant"></select>
+      <div class="gfp-row">
+        <div>
+          <label for="galleryFilterFrom">From</label>
+          <input type="date" id="galleryFilterFrom">
+        </div>
+        <div>
+          <label for="galleryFilterTo">To</label>
+          <input type="date" id="galleryFilterTo">
+        </div>
+      </div>
+      <div class="gfp-actions">
+        <button class="ghost tiny" id="galleryFilterClear">Clear</button>
+        <button class="tiny" id="galleryFilterApply">Apply</button>
+      </div>
+    </div>
     <button class="gallery-nav prev" id="galleryPrev" aria-label="Previous">‹</button>
     <button class="gallery-nav next" id="galleryNext" aria-label="Next">›</button>
+    <div class="gallery-empty" id="galleryEmpty" style="display:none">No photos match the current filters.</div>
   </div>
 </div>
 
@@ -804,8 +836,20 @@ $('#themechip').onclick = ()=>{
 
 /* ---------- photo gallery ---------- */
 const GALLERY_KEY = 'yardDashboard.galleryOn';
-const galleryState = { pool: [], idx: 0, current: 'A', timer: null, paused: false };
+const GALLERY_FILTER_KEY = 'yardDashboard.galleryFilter';
+const galleryState = { pool: [], idx: 0, current: 'A', timer: null, paused: false, filter: loadGalleryFilter() };
 
+function loadGalleryFilter(){
+  try { return Object.assign({plantId:'', from:'', to:''}, JSON.parse(localStorage.getItem(GALLERY_FILTER_KEY)||'{}')); }
+  catch { return {plantId:'', from:'', to:''}; }
+}
+function saveGalleryFilter(){
+  localStorage.setItem(GALLERY_FILTER_KEY, JSON.stringify(galleryState.filter));
+}
+function isGalleryFilterActive(){
+  const f = galleryState.filter;
+  return !!(f.plantId || f.from || f.to);
+}
 function isGalleryOn(){
   const v = localStorage.getItem(GALLERY_KEY);
   return v === null ? true : v === '1';  // default on
@@ -819,27 +863,54 @@ function applyGalleryToggle(){
   const panel = $('#galleryPanel');
   const chip = $('#gallerychip');
   if (chip) chip.textContent = on ? '🖼 gallery on' : '🖼 gallery off';
+  updateGalleryFilterButton();
   if (!panel) return;
-  if (on && galleryState.pool.length){
+  const filterActive = isGalleryFilterActive();
+  const havePool = galleryState.pool.length > 0;
+  // Show the strip when gallery is on AND we either have photos OR have an
+  // active filter (so the user can see the empty state and clear filters).
+  if (on && (havePool || filterActive)){
     panel.style.display = '';
-    startGallery();
+    const empty = $('#galleryEmpty');
+    const a = $('#galleryImgA'), b = $('#galleryImgB'), cap = $('#galleryCaption'), dots = $('#galleryDots');
+    if (havePool){
+      if (empty) empty.style.display = 'none';
+      [a,b,cap,dots].forEach(el => { if (el) el.style.display = ''; });
+      startGallery();
+    } else {
+      // Filter active, no matches — show empty state and hide the rotating bits
+      if (empty) empty.style.display = '';
+      [cap, dots].forEach(el => { if (el) el.style.display = 'none'; });
+      [a, b].forEach(el => { if (el){ el.style.display = 'none'; el.removeAttribute('src'); } });
+      stopGallery();
+    }
   } else {
     panel.style.display = 'none';
     stopGallery();
   }
 }
 function buildGalleryPool(){
+  const f = galleryState.filter;
   const items = [];
   for (const p of (state.plants||[])){
+    if (f.plantId && p.id !== f.plantId) continue;
     for (const ph of (p.photos||[])){
       if (!ph || !ph.key) continue;
-      items.push({ plantId: p.id, plantName: p.name, key: ph.key, date: ph.date || '', caption: ph.caption || '' });
+      const d = ph.date || '';
+      if (f.from && (!d || d < f.from)) continue;
+      if (f.to && (!d || d > f.to)) continue;
+      items.push({ plantId: p.id, plantName: p.name, key: ph.key, date: d, caption: ph.caption || '' });
     }
   }
-  // Fisher-Yates shuffle
-  for (let i = items.length - 1; i > 0; i--){
-    const j = Math.floor(Math.random() * (i + 1));
-    [items[i], items[j]] = [items[j], items[i]];
+  if (f.plantId){
+    // Single-plant: chronological is more useful than random
+    items.sort((a,b)=>(a.date||'').localeCompare(b.date||''));
+  } else {
+    // Fisher-Yates shuffle
+    for (let i = items.length - 1; i > 0; i--){
+      const j = Math.floor(Math.random() * (i + 1));
+      [items[i], items[j]] = [items[j], items[i]];
+    }
   }
   galleryState.pool = items;
   galleryState.idx = 0;
@@ -877,18 +948,84 @@ function stopGallery(){
   if (galleryState.timer){ clearInterval(galleryState.timer); galleryState.timer = null; }
 }
 function refreshGallery(){
-  // Only rebuild + restart if the underlying photo set changed.
+  // Only rebuild + restart if the photo set OR the active filter changed.
   const keys = [];
   for (const p of (state.plants||[])) for (const ph of (p.photos||[])) if (ph && ph.key) keys.push(ph.key);
-  const sig = keys.sort().join('|');
+  const f = galleryState.filter;
+  const sig = keys.sort().join('|') + '#' + f.plantId + '|' + f.from + '|' + f.to;
   if (sig === galleryState.sig){ applyGalleryToggle(); return; }
   galleryState.sig = sig;
+  stopGallery();
   buildGalleryPool();
   applyGalleryToggle();
+}
+function applyGalleryFilter(newFilter){
+  galleryState.filter = Object.assign({plantId:'', from:'', to:''}, newFilter || {});
+  saveGalleryFilter();
+  updateGalleryFilterButton();
+  refreshGallery();
+}
+function updateGalleryFilterButton(){
+  const btn = $('#galleryFilterBtn');
+  if (!btn) return;
+  const active = isGalleryFilterActive();
+  btn.classList.toggle('is-active', active);
+  if (!active){ btn.textContent = '⚲ filter'; return; }
+  const f = galleryState.filter;
+  const parts = [];
+  if (f.plantId){
+    const p = (state.plants||[]).find(p => p.id === f.plantId);
+    parts.push(p ? p.name : 'plant');
+  }
+  if (f.from || f.to) parts.push((f.from||'…') + '→' + (f.to||'…'));
+  btn.textContent = '⚲ ' + parts.join(' · ');
+}
+function populateGalleryFilterUI(){
+  const sel = $('#galleryFilterPlant'); if (!sel) return;
+  const f = galleryState.filter;
+  const opts = ['<option value="">All plants</option>'];
+  for (const p of (state.plants||[]).slice().sort((a,b)=>(a.name||'').localeCompare(b.name||''))){
+    opts.push(`<option value="${p.id}">${escapeHtml(p.name)}</option>`);
+  }
+  sel.innerHTML = opts.join('');
+  sel.value = f.plantId || '';
+  $('#galleryFilterFrom').value = f.from || '';
+  $('#galleryFilterTo').value = f.to || '';
+}
+function toggleGalleryFilterPop(force){
+  const pop = $('#galleryFilterPop');
+  const btn = $('#galleryFilterBtn');
+  const open = force === undefined ? !pop.classList.contains('is-open') : !!force;
+  if (open) populateGalleryFilterUI();
+  pop.classList.toggle('is-open', open);
+  btn.setAttribute('aria-expanded', open ? 'true' : 'false');
 }
 $('#gallerychip').onclick = () => setGalleryOn(!isGalleryOn());
 $('#galleryPrev').onclick = (e) => { e.stopPropagation(); advanceGallery(-1); };
 $('#galleryNext').onclick = (e) => { e.stopPropagation(); advanceGallery(1); };
+$('#galleryFilterBtn').onclick = (e) => { e.stopPropagation(); toggleGalleryFilterPop(); };
+$('#galleryFilterPop').addEventListener('click', e => e.stopPropagation());
+$('#galleryFilterApply').onclick = (e) => {
+  e.stopPropagation();
+  applyGalleryFilter({
+    plantId: $('#galleryFilterPlant').value,
+    from: $('#galleryFilterFrom').value,
+    to: $('#galleryFilterTo').value,
+  });
+  toggleGalleryFilterPop(false);
+};
+$('#galleryFilterClear').onclick = (e) => {
+  e.stopPropagation();
+  applyGalleryFilter({plantId:'', from:'', to:''});
+  populateGalleryFilterUI();
+};
+// Click outside the popover closes it
+document.addEventListener('click', (e) => {
+  const pop = $('#galleryFilterPop');
+  if (pop && pop.classList.contains('is-open') && !pop.contains(e.target) && e.target.id !== 'galleryFilterBtn'){
+    toggleGalleryFilterPop(false);
+  }
+});
 $('#galleryStage').addEventListener('mouseenter', () => { galleryState.paused = true; });
 $('#galleryStage').addEventListener('mouseleave', () => { galleryState.paused = false; });
 [$('#galleryImgA'), $('#galleryImgB')].forEach(img => {


### PR DESCRIPTION
## Summary
Two gallery improvements in one PR:

1. **Less aggressive cropping on desktop** — switched from 21:9 to 3:2 (with a 560px max-height to cap the size on ultra-wide monitors). Portrait phone shots now show much more of the frame. Mobile stays at 4:3.
2. **Filters** — pick a single plant and/or a date range. Default is unfiltered + random across the whole collection.

## What's new
- **⚲ filter button** in the top-left of the gallery opens a popover with:
  - Plant select (alphabetical, "All plants" default)
  - From / To date inputs
  - Apply / Clear buttons
- **Persistent filter** stored in localStorage as `yardDashboard.galleryFilter`. Reload keeps your filter.
- **Active state** — when filters are on, the button turns teal and shows a label summary (plant name and/or date range) so it's obvious the strip isn't showing the full collection.
- **Single-plant pool sorts chronologically** instead of shuffling — feels more like a sequence than a slideshow when you've isolated one plant's history.
- **Empty state** — if the filter matches zero photos, the strip stays visible with "No photos match the current filters" so you can clear filters. Without that fallback the panel hid itself and you couldn't get back.

## Implementation notes
- The change-detection signature now includes filter state, so `applyGalleryFilter()` triggers a rebuild + restart.
- Filter popover uses `stopPropagation` on its container so clicks inside don't bubble to the image (which would open the lightbox), and a document-level click-outside handler closes it.
- Date range comparisons use lexicographic compare on `YYYY-MM-DD` (no Date parsing needed).
- Photos without a date are excluded when a date range is active, since they can't be compared.

## Test plan
- [ ] Open dashboard with photos → strip is shorter/taller than before, portrait shots show more of the photo
- [ ] Click ⚲ filter → popover appears, plant select is populated alphabetically
- [ ] Pick a plant → Apply → strip rotates only that plant's photos in chronological order
- [ ] Set From and To dates → Apply → strip restricts to that window
- [ ] Active filter shows in button label and button is teal
- [ ] Click Clear → filter resets to all photos, button returns to "⚲ filter"
- [ ] Refresh page → filter persists
- [ ] Apply filter that matches zero photos → "No photos match" message appears, strip stays visible
- [ ] Click outside popover → popover closes
- [ ] Resize to mobile → 4:3 ratio kicks in, popover still usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)