### PR TITLE
Stats year fill + lightbox-over-info-modal + 'Our Plants' title

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="Plants">
-<title>Scott and Stacy's Plants</title>
+<title>Our Plants</title>
 <style>
   :root{
     --bg:#08191c;            /* deep teal, near-black */
@@ -371,7 +371,7 @@
 
 <header>
   <div>
-    <h1>Scott and Stacy's Plants</h1>
+    <h1>Our Plants</h1>
     <div class="sub" id="dateline">—</div>
   </div>
   <div class="row">
@@ -584,7 +584,7 @@
   </div>
 </div>
 
-<div class="modal-back" id="lightbox" style="background:rgba(0,0,0,.92);">
+<div class="modal-back" id="lightbox" style="background:rgba(0,0,0,.92);z-index:60">
   <div style="position:relative;max-width:96vw;max-height:96vh;display:flex;flex-direction:column;align-items:center;gap:10px">
     <button class="close" id="lightboxClose" style="position:absolute;top:-6px;right:-6px;color:#fff;font-size:28px">×</button>
     <img id="lightboxImg" style="max-width:96vw;max-height:80vh;object-fit:contain;border-radius:8px;background:#0a0a0a">
@@ -2699,7 +2699,10 @@ function renderStats(){
       targetEl.innerHTML = `<div class="stats-empty">${emptyMsg}</div>`;
       return;
     }
-    const minY = Math.min(...byYear.keys()), maxY = Math.max(...byYear.keys());
+    // Extend through the current year so empty recent years still show as zero bars.
+    const currentYear = new Date().getFullYear();
+    const minY = Math.min(...byYear.keys());
+    const maxY = Math.max(currentYear, ...byYear.keys());
     const series = [];
     for (let y=minY; y<=maxY; y++) series.push([y, byYear.get(y)||0]);
     const w = 360, h = 200, padL = 24, padR = 12, padT = 16, padB = 28;


### PR DESCRIPTION
## Summary
Three small fixes from one round of testing:

1. **Per-year stats charts now extend through the current year.** Trailing zero bars render so empty recent years don't silently disappear from the timeline.
2. **Photo lightbox now layers above the plant info modal.** Tapping a photo from a plant popup on mobile was opening the lightbox behind the info modal, so the photo stayed hidden until you × out of the info popup. Lightbox bumped to `z-index: 60`; the info modal stays open underneath, and closing the lightbox drops you right back into the plant detail.
3. **Title** — both the browser tab `<title>` and the on-page `<h1>` renamed to "Our Plants".

## Implementation notes
- The chart fix: `drawYearBars` now does `maxY = Math.max(currentYear, ...byYear.keys())`. `minY` stays anchored to the earliest data year so the timeline doesn't grow toward both ends — only forward.
- The z-index fix is inline on `#lightbox` rather than touching the `.modal-back` base rule, since the other modals (info, weather) are intentionally same-tier; only the lightbox should float above them.
- Root cause analysis on the lightbox: both modals shared `z-index: 50` from the shared `.modal-back` rule. With equal stacking, DOM order decides — and `#infoModal` is later in the document than `#lightbox`, so it painted on top.

## Test plan
- [ ] Open the dashboard → "Our Plants" appears in the browser tab and as the page heading.
- [ ] Stats panel: acquisitions and money-spent charts now show 2025 / 2026 (zero) bars on the right edge if there's been no recent purchase.
- [ ] On mobile (or narrow window): click a plant name → info modal opens → tap a photo thumbnail → lightbox fills the screen with the photo on top → close → returns to the info modal still on screen.
- [ ] Lightbox prev/next still work; tapping outside the photo still closes the lightbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)