### PR TITLE
Auto-retry failed sync pushes + tap-to-retry chip

### DIFF
--- a/index.html
+++ b/index.html
@@ -1216,7 +1216,16 @@ $('#settingsBtn').onclick = ()=>{
   if (p.style.display === 'block') p.style.display = 'none';
   else openSettings();
 };
-$('#syncchip').onclick = openSettings;
+$('#syncchip').onclick = ()=>{
+  // If we're in an error state with a pending retry, tapping the chip retries now.
+  const chip = $('#syncchip');
+  if (chip.textContent.includes('error') && getToken()){
+    if (pushRetryTimer){ clearTimeout(pushRetryTimer); pushRetryTimer = null; }
+    pushNow();
+    return;
+  }
+  openSettings();
+};
 $('#syncchip').style.cursor = 'pointer';
 $('#locchip').onclick = openSettings;
 $('#locchip').style.cursor = 'pointer';
@@ -2807,9 +2816,11 @@ async function pullFromRemote(){
   } finally { syncing = false; }
 }
 
+let pushRetryTimer = null;
 async function pushNow(){
   if (!getToken() || syncing) return;
   syncing = true;
+  if (pushRetryTimer){ clearTimeout(pushRetryTimer); pushRetryTimer = null; }
   try {
     setSyncStatus('pushing…');
     await pushWithRetry(5);
@@ -2817,7 +2828,11 @@ async function pushNow(){
     suspendSync = true; saveLocal(); suspendSync = false;
     setSyncStatus(`synced ${new Date().toLocaleTimeString()}`, 'ok');
   } catch(e){
-    setSyncStatus('error: '+e.message, 'err');
+    // Local data is safe in localStorage. Schedule a background retry so the
+    // sync recovers without the user having to make another change. Click the
+    // chip (or "Push now" in Settings) to retry immediately.
+    setSyncStatus('error · retry pending — tap to retry', 'err');
+    pushRetryTimer = setTimeout(() => { pushRetryTimer = null; pushNow(); }, 30000);
   } finally { syncing = false; }
 }
 


### PR DESCRIPTION
## Summary
After editing a log (or any other change), the GitHub PUT would occasionally fail with a 409 SHA mismatch — typically because another tab/device wrote to data.json in the same window. \`pushWithRetry\` already does 5 attempts with backoff, but if those exhaust, \`pushNow\` would throw and the chip would stick in 'error' state until the user happened to make another change. Local data was always safe in localStorage, but the UX made it look like the edit didn't take.

## Changes
- **Auto-retry** — after a failed push, schedule a background retry in 30 seconds via a new \`pushRetryTimer\`. Any subsequent push (manual or queued) cancels the timer.
- **Tap-to-retry chip** — clicking the sync chip while in error state cancels the pending retry and runs \`pushNow\` immediately. Outside error state the chip still opens Settings as before.
- Chip text updated to hint at this: "error · retry pending — tap to retry".

## Why this is safe
- Local edits stay in localStorage from \`save()\` until they're successfully pushed. The retry just keeps trying to upload them.
- \`pushWithRetry\` always refetches the SHA, so each retry sees the latest remote state.
- Log entries are merged by id (preserving local edits) before each PUT.

## Test plan
- [ ] Edit a log entry → if push fails, chip shows "error · retry pending — tap to retry".
- [ ] Wait 30s → push retries automatically and (if remote isn't conflicting anymore) succeeds; chip flips to "synced HH:MM:SS".
- [ ] Tap the chip while it shows error → push retries immediately.
- [ ] Edit another log while in error state → existing queueSync fires, cancels pending retry, attempts push now.
- [ ] Reload after a stuck error → next change triggers a fresh push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)