### PR TITLE
Restore actual error text on sync chip + console logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -2720,8 +2720,9 @@ async function ghFetch(){
     cache: 'no-store',
   });
   if (r.status === 404) return {sha:null, data:null};
-  if (!r.ok) throw new Error(`fetch ${r.status}`);
+  if (!r.ok){ console.warn('[sync] GET failed', r.status); throw new Error(`fetch ${r.status}`); }
   const j = await r.json();
+  console.debug('[sync] GET data.json sha:', j.sha);
   return { sha: j.sha, data: JSON.parse(b64utf8(j.content)) };
 }
 
@@ -2734,12 +2735,17 @@ async function ghPut(blob, sha){
     branch: GH.branch,
   };
   if (sha) body.sha = sha;
+  console.debug('[sync] PUT data.json with sha:', sha || '(none)');
   const r = await fetch(url, {
     method:'PUT',
     headers:{Authorization:`token ${t}`, Accept:'application/vnd.github+json','Content-Type':'application/json'},
     body: JSON.stringify(body),
   });
-  if (!r.ok){ const err = await r.json().catch(()=>({})); throw new Error(`PUT ${r.status}: ${err.message||''}`); }
+  if (!r.ok){
+    const err = await r.json().catch(()=>({}));
+    console.warn('[sync] PUT failed', r.status, err);
+    throw new Error(`PUT ${r.status}: ${err.message||''}`);
+  }
   const j = await r.json();
   return j.content.sha;
 }
@@ -2846,7 +2852,9 @@ async function pushNow(){
     // Local data is safe in localStorage. Schedule a background retry so the
     // sync recovers without the user having to make another change. Click the
     // chip (or "Push now" in Settings) to retry immediately.
-    setSyncStatus('error · retry pending — tap to retry', 'err');
+    console.error('[sync] pushNow failed:', e);
+    const short = (e && e.message ? e.message : String(e)).replace(/^PUT\s*/, '').slice(0, 80);
+    setSyncStatus(`error: ${short} · tap to retry`, 'err');
     pushRetryTimer = setTimeout(() => { pushRetryTimer = null; pushNow(); }, 30000);
   } finally { syncing = false; }
 }


### PR DESCRIPTION
## Summary
The previous tap-to-retry fix simplified the chip text to \"error · retry pending — tap to retry\" but in doing so dropped the underlying error message. Without it, we can't tell what's actually failing in the user's repeated 409 reports.

## Changes
- **Chip text** now reads \`error: <message> · tap to retry\` with the underlying error truncated to 80 chars.
- **Console logging** added to \`ghFetch\` (success: returned sha; failure: status), \`ghPut\` (success: sha used; failure: status + parsed body), and \`pushNow\` (final error with full Error).
- No behavioral change — purely diagnostic visibility.

## Why a separate PR
We need the user to capture the actual error string on their next reproduction. With the previous chip text alone, we can't tell whether the storm is sha-mismatch (409), auth (401), rate limit (403), or validation (422). Each has a very different fix.

## Test plan
- [ ] Reproduce the error → chip now shows the GitHub error message.
- [ ] Open browser console → see \`[sync] PUT ... sha: ...\` and \`[sync] PUT failed N {body}\` messages preceding the chip update.
- [ ] Forward the chip text + console output for next-step diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)