### PR TITLE
Fix CORS preflight: drop Cache-Control header from GitHub GET

### DIFF
--- a/index.html
+++ b/index.html
@@ -2713,10 +2713,13 @@ function syncBlob(){
 
 async function ghFetch(){
   const t = getToken(); if (!t) throw new Error('no token');
-  // Cache-bust the URL — defends against browser/CDN intermediaries returning stale data.
+  // Cache-bust via URL only. NOTE: do NOT add Cache-Control: no-cache as a
+  // request header — GitHub's API CORS policy doesn't allow it, and the
+  // preflight rejection causes "Failed to fetch" with no actual server hit.
+  // The URL timestamp + fetch's cache: 'no-store' is enough.
   const url = `https://api.github.com/repos/${GH.owner}/${GH.repo}/contents/${GH.path}?ref=${GH.branch}&_=${Date.now()}`;
   const r = await fetch(url, {
-    headers:{Authorization:`token ${t}`, Accept:'application/vnd.github+json', 'Cache-Control':'no-cache'},
+    headers:{Authorization:`token ${t}`, Accept:'application/vnd.github+json'},
     cache: 'no-store',
   });
   if (r.status === 404) return {sha:null, data:null};


### PR DESCRIPTION
## Root cause
The previous \"sync hardening\" PR added \`Cache-Control: no-cache\` as a request header to \`ghFetch\`. GitHub's api.github.com CORS policy doesn't include \`cache-control\` in its \`Access-Control-Allow-Headers\` preflight response, so the browser rejects the actual GET before it leaves the machine. Every sync attempt failed with \`TypeError: Failed to fetch\`, surfacing as the recurring chip error.

## Console excerpt that pinpointed it
> Access to fetch at 'https://api.github.com/...' from origin 'https://satownsend.github.io' has been blocked by CORS policy: Request header field cache-control is not allowed by Access-Control-Allow-Headers in preflight response.

## Fix
- Removed the \`Cache-Control: no-cache\` request header from \`ghFetch\`.
- Kept the URL cache-buster (\`&_=<timestamp>\`) and \`fetch({ cache: 'no-store' })\` — both achieve cache-busting without triggering a preflight.
- Added a comment in the source so this doesn't get reintroduced.

## Test plan
- [ ] Refresh dashboard → no more \"Failed to fetch\" in console; \`[sync] GET data.json sha: ...\` log appears.
- [ ] Edit a log → chip flips to \"synced HH:MM:SS\".
- [ ] Refresh again → all changes persisted on remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)