### PR TITLE
Wider info popup + bigger Then-vs-Now photos

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,7 @@
   .photo-timeline{margin-bottom:10px;border:1px solid var(--line2);border-radius:10px;overflow:hidden;background:var(--bg2)}
   .photo-timeline .pt-stage{position:relative;width:100%;aspect-ratio:1/1;background:#000;display:flex;align-items:center;justify-content:center;cursor:pointer;max-height:70vh}
   /* Plant info modal gets a wider frame so the timeline photo has more room */
-  #infoModal .modal{max-width:760px}
+  #infoModal .modal{max-width:960px}
   .photo-timeline .pt-stage img{width:100%;height:100%;object-fit:contain;display:block}
   .photo-timeline .pt-counter{position:absolute;top:8px;right:10px;background:rgba(0,0,0,.55);color:#fff;font-size:11px;padding:3px 8px;border-radius:999px;font-variant-numeric:tabular-nums}
   .photo-timeline .pt-controls{padding:10px 12px}
@@ -287,9 +287,9 @@
   .photo-timeline .pt-meta{display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--muted);margin-top:4px;font-variant-numeric:tabular-nums}
   .photo-timeline .pt-current{color:var(--accent);font-weight:600;font-size:13px}
   .photo-timeline .pt-edge{opacity:.7}
-  .then-now{display:grid;grid-template-columns:1fr 1fr;gap:8px;align-items:start}
+  .then-now{display:grid;grid-template-columns:1fr 1fr;gap:14px;align-items:start}
   .then-now figure{margin:0;text-align:center}
-  .then-now img{width:100%;border-radius:8px;display:block}
+  .then-now img{width:100%;aspect-ratio:1/1;object-fit:contain;background:#000;border-radius:10px;display:block}
   .then-now figcaption{font-size:11px;color:var(--muted);margin-top:4px;text-transform:uppercase;letter-spacing:.06em}
   .then-now .age{font-size:12px;color:var(--ink-soft);margin-top:2px}
   .topline{font-size:18px;line-height:1.4;margin:0 0 8px}


### PR DESCRIPTION
## Summary
Two desktop polish items for the plant info modal:

- Modal widened from 760px → 960px max-width on desktop.
- Then-vs-Now photos enlarged and normalized to identical square sizes for an honest side-by-side comparison.

## Changes
- \`#infoModal .modal\` bumped to \`max-width: 960px\`. The existing \`max-height: 90vh\` + scroll is unchanged, so taller photos won't break the layout.
- \`.then-now img\` now: \`aspect-ratio: 1/1; object-fit: contain; background: #000;\` — both photos display in identical 1:1 frames, letterboxed cleanly when the source isn't square. Bumped the grid gap from 8px → 14px to breathe at the new size.

## Why aspect-ratio: 1/1 + object-fit: contain
Previously the images were unconstrained — a tall portrait paired with a wide landscape rendered at very different sizes, making side-by-side comparison feel uneven. Square frame with contain keeps the comparison honest while showing the full photo (no cropping).

## Test plan
- [ ] Desktop: open a plant info modal → noticeably wider than before.
- [ ] Open Then vs Now → both photos appear in the same square frame at ~440×440.
- [ ] Pair a portrait + landscape photo → both render in identical frames with appropriate letterboxing.
- [ ] Mobile (\<700px width): modal still spans the screen with normal mobile padding.
- [ ] Photo grid thumbnails and timeline scrubber scale up to fill the new width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)