### PR TITLE
Mobile: name-only plant list + align gallery/brief widths with grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,6 +351,8 @@
     /* Hide cells with no value to reduce noise */
     #plantTable td.is-empty,
     #plantTable td.is-empty-mobile{display:none}
+    /* Mobile: only show name + edit button — collapse the rest into the tap-to-open card */
+    #plantTable td[data-col]:not([data-col="name"]):not([data-col="edit"]){display:none}
     /* Edit button: top-right of card */
     #plantTable td:last-child{
       position:absolute;top:10px;right:10px;padding:0;
@@ -434,7 +436,9 @@
   </div>
 </header>
 
-<div class="gallery" id="galleryPanel" style="display:none">
+<div class="grid" style="margin-top:16px">
+
+<div class="gallery" id="galleryPanel" style="display:none;grid-column:1/-1">
   <div class="gallery-stage" id="galleryStage">
     <img class="gallery-img is-current" id="galleryImgA" alt="">
     <img class="gallery-img" id="galleryImgB" alt="">
@@ -470,8 +474,6 @@
   <p class="topline" id="topline">Loading…</p>
   <div class="tasks"><ul id="taskList"></ul></div>
 </div>
-
-<div class="grid" style="margin-top:16px">
 
   <div class="panel">
     <h2>Forecast</h2>


### PR DESCRIPTION
## Summary
Two layout/mobile polish items:

1. **Mobile plant list shows only the name** — cleaner thumb-scroll. Tap name → info modal for full details.
2. **Gallery and Today's Brief moved inside the same grid as the rest of the panels** — structurally aligned with the forecast/log row instead of living at the wrap level.

## Changes

### Mobile plant list
The existing mobile rules already convert each table row into a card with the name as a heading. Added one rule to hide every other column:
\`\`\`css
#plantTable td[data-col]:not([data-col="name"]):not([data-col="edit"]){display:none}
\`\`\`
Each card now shows just the plant name + edit button. Tap the name → info modal (full details, photos, log history, etc).

### Gallery + Brief in the grid
Previously \`#galleryPanel\` and \`#briefPanel\` were direct children of \`.wrap\`, sitting above the \`.grid\`. Moved both INTO the grid.
- Gallery: inline \`grid-column:1/-1\` so it spans both columns.
- Brief: already had \`.panel.full\` (which sets \`grid-column:1/-1\`).
- Both now share the grid's gap, containment, and alignment with forecast/log/plants/etc.

## Test plan
- [ ] On mobile (<700px): plant list shows only the name + edit button per row. Tap name → info modal opens with everything.
- [ ] On desktop: gallery + brief still span the full content area; visually aligned with forecast/log row below.
- [ ] On mobile: gallery, brief, forecast, log all stack at the same width.
- [ ] No horizontal scrollbar; no layout shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)