### PR TITLE
Hide stage / pot / tag pills from plant list rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -1657,7 +1657,7 @@ function renderPlants(){
     const cellNotes = p.notes ? `<span class="meta">${escapeHtml(p.notes)}</span>` : '';
     const empty = (s) => !s || s === '' ? 'is-empty' : '';
     tr.innerHTML = `
-      <td data-col="name"><a href="#" class="namelink" data-info="${p.id}">${escapeHtml(p.name)}</a>${p.dead?' <span class="pill rip">RIP</span>':''}${stagePill}${(p.container===true||p.container==='true')?' <span class="pill">pot</span>':''}${tagBadges}</td>
+      <td data-col="name"><a href="#" class="namelink" data-info="${p.id}">${escapeHtml(p.name)}</a>${p.dead?' <span class="pill rip">RIP</span>':''}</td>
       <td data-col="type" data-label="Latin name" class="${empty(cellType)}">${cellType||'<span class="meta">—</span>'}</td>
       <td data-col="qty" data-label="Qty" class="${qty>1?'':'is-empty-mobile'}">${cellQty}</td>
       <td data-col="category" data-label="Type" class="${empty(cellCategory)}">${cellCategory||'<span class="meta">—</span>'}</td>


### PR DESCRIPTION
## Summary
The plant table's name column had several inline pills (stage like "establishing", "pot" for containers, all comma-separated tags). It cluttered the list on both desktop and mobile.

## Change
- Removed \`stagePill\`, the pot pill, and \`tagBadges\` from the name cell render.
- Kept the **RIP** pill — that's a lifecycle status, not a category tag, and the row also has the \`.dead\` class for crossed-out styling.

## Where the data still lives
- All of these fields are still visible per-plant in the info modal (Tags row, Container row, Stage row in the kv list).
- The Type column still shows category (Tree / Shrub / etc).

## Test plan
- [ ] Desktop: rows show just the name (and RIP for departed). Cleaner.
- [ ] Mobile: card layout already only shows name + edit; pills are gone there too.
- [ ] Open a plant info modal → Tags / Container / Stage all still surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)