### PR TITLE
Switch title font to Clother Bold (Adobe Fonts)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,8 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="Plants">
 <title>Our Plants</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,700;1,9..144,500;1,9..144,700&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://use.typekit.net" crossorigin>
+<link rel="stylesheet" href="https://use.typekit.net/twp1irx.css">
 <style>
   :root{
     --bg:#08191c;            /* deep teal, near-black */
@@ -62,7 +61,7 @@
   a{color:var(--accent);text-decoration:none}
   .wrap{max-width:1200px;margin:0 auto;padding:24px 20px 80px}
   header{display:flex;align-items:baseline;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:18px}
-  h1{font:italic 700 30px/1.1 "Fraunces", "Playfair Display", Georgia, serif;margin:0;letter-spacing:-.015em;color:var(--accent);font-variation-settings:"opsz" 96, "SOFT" 50}
+  h1{font:700 30px/1.1 "clother", -apple-system, BlinkMacSystemFont, "SF Pro Display", sans-serif;margin:0;letter-spacing:-.015em;color:var(--accent)}
   h2{font:600 14px/1 "SF Pro Display",sans-serif;margin:0 0 12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
   .sub{color:var(--muted);font-size:13px}
   .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}


### PR DESCRIPTION
## Summary
Swapped the page title from Fraunces (Google Fonts) to **Clother Bold** loaded via the Adobe Fonts kit URL.

## Changes
- Replaced the Fraunces \`<link>\` with the Typekit URL: \`https://use.typekit.net/twp1irx.css\`.
- Added a \`preconnect\` to \`use.typekit.net\` for first-paint speed.
- \`h1\` now uses \`font: 700 30px "clother", system-fallback\`. No italic, no axis tuning (those were Fraunces-specific).

## Note on font-family name
Adobe Fonts kits typically expose families as lowercase, e.g. \`"clother"\`. If the rendered title falls back to the system font, the kit's CSS may use a different family token — easy fix once we know the exact name.

## Test plan
- [ ] Refresh the dashboard → title renders in Clother Bold (sans-serif, no italic).
- [ ] DevTools → check that the typekit stylesheet loads with HTTP 200.
- [ ] If it still falls back: open \`https://use.typekit.net/twp1irx.css\` directly to find the actual \`font-family\` name and we'll update the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)