### PR TITLE
Add 'taken outside' / 'brought inside' log actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,6 +496,8 @@
         <option value="repotted">repotted</option>
         <option value="covered">covered</option>
         <option value="uncovered">uncovered</option>
+        <option value="taken outside">taken outside</option>
+        <option value="brought inside">brought inside</option>
         <option value="frost">frost</option>
         <option value="frost damage">frost damage</option>
         <option value="note">note</option>


### PR DESCRIPTION
## Summary
Two new entries in the Quick log action dropdown — for the seasonal "moved this potted plant outside for the summer" / "brought it back inside before frost" cycle.

## Changes
- Added \`taken outside\` and \`brought inside\` to \`#logAction\`, positioned right after \`covered\` / \`uncovered\` since they're all the same family of seasonal protection moves.
- The log edit modal's action select clones its options from \`#logAction\` at open time, so it picks these up automatically.

## Test plan
- [ ] Quick log → action dropdown lists "taken outside" and "brought inside" between "uncovered" and "frost".
- [ ] Log either action against a plant → appears in Recent log + the plant's per-plant log history.
- [ ] Open an existing entry's edit modal → action dropdown also lists the new options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)