### PR TITLE
Parse MM/YYYY (and YYYY-MM) date formats from sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -2863,9 +2863,18 @@ function plantSlug(name){
 function normalizeDate(s){
   if (!s) return '';
   s = String(s).trim();
+  // ISO YYYY-MM-DD
   if (/^\d{4}-\d{2}-\d{2}/.test(s)) return s.slice(0,10);
-  let m = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+  // ISO YYYY-MM (month only, default to day 1)
+  let m = s.match(/^(\d{4})-(\d{1,2})$/);
+  if (m) return `${m[1]}-${m[2].padStart(2,'0')}-01`;
+  // US M/D/YYYY (or MM/DD/YYYY)
+  m = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
   if (m) return `${m[3]}-${m[1].padStart(2,'0')}-${m[2].padStart(2,'0')}`;
+  // US M/YYYY (month + year only, default to day 1) — also handles MM-YYYY
+  m = s.match(/^(\d{1,2})[\/\-](\d{4})$/);
+  if (m) return `${m[2]}-${m[1].padStart(2,'0')}-01`;
+  // Bare year YYYY (default to Jan 1)
   if (/^\d{4}$/.test(s)) return `${s}-01-01`;
   return '';
 }


### PR DESCRIPTION
## Root cause
\`normalizeDate()\` only matched these formats:
- \`YYYY-MM-DD\`
- \`MM/DD/YYYY\`
- \`YYYY\`

Sheet rows like \`06/2021\` or \`10/2025\` — month + year, no day — fell through to the empty-string return. Plants with those purchased dates lost their date entirely on every sheet pull, vanishing from the per-year stats charts.

## Fix
Added matchers for:
- \`YYYY-MM\`
- \`M/YYYY\` and \`MM/YYYY\`
- \`M-YYYY\` and \`MM-YYYY\`

All default to day \`01\`, matching the existing bare-year (\`YYYY → YYYY-01-01\`) convention.

## Verified
Unit-tested 11 input cases (the new month-year formats plus regression cases for the existing formats). All pass.

## Test plan
- [ ] Sheet pull → plants like "Acer Palmatum Orangeola" (06/2021) now have a purchased date.
- [ ] Plants acquired per year / Money spent per year charts include those plants.
- [ ] Existing rows with full \`MM/DD/YYYY\` dates parse the same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)