### PR TITLE
Pin Open-Meteo to best_match model for US accuracy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1344,9 +1344,14 @@ async function fetchForecast(force=false){
   if (!force && !stale){ renderForecast(); return; }
   const tempUnit = s.units==='C' ? 'celsius' : 'fahrenheit';
   const precipUnit = s.units==='C' ? 'mm' : 'inch';
+  // models=best_match — for US points this routes to NOAA's NBM (National Blend
+  // of Models), matching what NWS / weather.gov publishes. More accurate than
+  // the global default for North American forecasts (especially overnight lows
+  // / frost predictions).
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${s.lat}&longitude=${s.lon}`+
     `&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,wind_speed_10m_max,weather_code`+
-    `&temperature_unit=${tempUnit}&precipitation_unit=${precipUnit}&wind_speed_unit=mph&timezone=auto&forecast_days=7`;
+    `&temperature_unit=${tempUnit}&precipitation_unit=${precipUnit}&wind_speed_unit=mph&timezone=auto&forecast_days=7`+
+    `&models=best_match`;
   try{
     const r = await fetch(url); const j = await r.json();
     state.forecast = j.daily; state.forecastFetched = Date.now(); save();


### PR DESCRIPTION
## Summary
One-line tweak to the forecast URL: appended \`&models=best_match\`. For US lat/lon points (like Lilly, PA at 40.4238, -78.6231), Open-Meteo will now use NOAA's NBM (National Blend of Models) — the same source NWS publishes — instead of its global default model.

## Why
The default routing wasn't always picking the regionally-optimal model. NBM is what your local meteorologist uses; using it should tighten overnight low / frost predictions noticeably.

## Test plan
- [ ] Refresh the dashboard → forecast still loads cleanly.
- [ ] Cross-check a day's high/low against api.weather.gov for Lilly, PA — should be within a degree or two.
- [ ] Watch over the next week — frost-risk warnings should be more reliable.

## Follow-up issue
A bigger refactor — switching directly to api.weather.gov — is filed as a future-feature issue alongside this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)