### PR TITLE
Show grand totals beneath per-year bar charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,8 @@
   .stats-pie svg:hover .pie-slice{opacity:.55}
   .stats-pie svg .pie-slice:hover{opacity:1;stroke-width:2.5}
   .stats-empty{color:var(--muted);font-size:13px;padding:20px 0}
+  .stats-total{margin-top:6px;padding-top:6px;border-top:1px solid var(--line2);font-size:12px;color:var(--ink-soft);font-variant-numeric:tabular-nums;text-align:right}
+  .stats-total:empty{display:none}
   .panel{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 18px;box-shadow:var(--shadow)}
   .panel.full{grid-column:1/-1}
   .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
@@ -608,10 +610,12 @@
       <div>
         <div class="small" style="margin-bottom:6px;color:var(--muted)">Plants acquired per year</div>
         <div id="statsBars"></div>
+        <div id="statsBarsTotal" class="stats-total"></div>
       </div>
       <div>
         <div class="small" style="margin-bottom:6px;color:var(--muted)">Money spent per year</div>
         <div id="statsSpend"></div>
+        <div id="statsSpendTotal" class="stats-total"></div>
       </div>
     </div>
   </div>
@@ -3620,8 +3624,29 @@ function renderStats(){
   drawYearBars('#statsBars', acquired, n => String(n), 'Plants acquired per year',
     'No purchase dates recorded.', 'var(--accent)');
   const fmtMoney = n => n >= 1000 ? '$'+Math.round(n/100)/10+'k' : '$'+Math.round(n);
+  // Pretty-format whole dollars with commas for the grand-total line
+  const fmtMoneyFull = n => '$' + Math.round(n).toLocaleString();
   drawYearBars('#statsSpend', spent, fmtMoney, 'Money spent per year',
     'No prices recorded in notes.', 'var(--accent2)');
+
+  // Grand totals beneath the per-year bar charts.
+  const acquiredTotal = [...acquired.values()].reduce((s,n) => s+n, 0);
+  const spentTotal    = [...spent.values()].reduce((s,n) => s+n, 0);
+  const yearsSpan     = (acquired.size + spent.size) > 0
+    ? Math.max(1, (new Date().getFullYear() - Math.min(...acquired.keys(), ...spent.keys()) + 1))
+    : 0;
+  const acqSummary = $('#statsBarsTotal');
+  if (acqSummary){
+    acqSummary.textContent = acquiredTotal
+      ? `Total: ${acquiredTotal} plant${acquiredTotal===1?'':'s'} · avg ${(acquiredTotal/yearsSpan).toFixed(1)}/yr`
+      : '';
+  }
+  const spendSummary = $('#statsSpendTotal');
+  if (spendSummary){
+    spendSummary.textContent = spentTotal
+      ? `Total: ${fmtMoneyFull(spentTotal)} · avg ${fmtMoneyFull(spentTotal/yearsSpan)}/yr`
+      : '';
+  }
 }
 
 function renderFrostLog(){


### PR DESCRIPTION
## Summary
The Money-spent and Plants-acquired bar charts only showed the per-year breakdown. Now each one has a small summary line beneath:
- \"Total: \$X,XXX · avg \$YYY/yr\"
- \"Total: N plants · avg X.X/yr\"

## Why a separate cumulative chart isn't worth it
A line overlay or full cumulative chart would:
- Need a second y-axis (cumulative quickly dwarfs any single-year bar)
- Crowd a panel that already has 4 charts
- Add a chart type to maintain

The simple total + average answers the actual question (\"how much have I spent total?\") in one line, with no extra UI.

## Implementation notes
- New \`fmtMoneyFull\` (uses \`toLocaleString\`) for readable totals (e.g. \"\$1,250\" instead of the bar-label-compact \"\$1.3k\").
- \`.stats-total:empty{display:none}\` hides the line when there's no data.
- Average is over years-elapsed-since-earliest-data, clamped to ≥1.

## Test plan
- [ ] Stats panel shows \"Total: \$X · avg \$Y/yr\" beneath the spend chart.
- [ ] Same format beneath the acquisitions chart.
- [ ] Numbers reflect quantity-weighted totals (matches the bars).
- [ ] If there's only one year of data, avg equals the year's value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)