### PR TITLE
Per-photo hide-from-gallery toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,6 +300,7 @@
   .photo-grid .ph:hover img{transform:scale(1.04)}
   .photo-grid .ph .date{position:absolute;left:0;right:0;bottom:0;background:linear-gradient(transparent,rgba(0,0,0,.75));color:#fff;font-size:10px;padding:14px 6px 4px;text-align:center;font-weight:600;letter-spacing:.04em}
   .photo-grid .ph-linked{position:absolute;top:4px;right:4px;background:rgba(0,0,0,.55);color:#fff;font-size:11px;padding:2px 5px;border-radius:8px;line-height:1}
+  .photo-grid .ph-hidden{position:absolute;top:4px;left:4px;background:rgba(0,0,0,.55);color:#fff;font-size:11px;padding:2px 5px;border-radius:8px;line-height:1}
   #lightboxAlsoIn .lb-chip{display:inline-flex;align-items:center;gap:4px;background:rgba(255,255,255,.12);color:#fff;border:1px solid rgba(255,255,255,.2);border-radius:999px;padding:2px 4px 2px 9px;font-size:12px}
   #lightboxAlsoIn .lb-chip-x{background:transparent;border:none;color:#fff;cursor:pointer;padding:0 4px;font-size:14px;line-height:1}
   #lightboxAlsoIn .lb-chip-x:hover{color:#f59a8a}
@@ -704,6 +705,10 @@
       <input type="date" id="lightboxDate" style="background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.2);color:#fff;border-radius:6px;padding:5px 10px;font-weight:600;text-align:center;color-scheme:dark">
       <input type="text" id="lightboxCaption" placeholder="add caption…" style="background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.2);color:#fff;border-radius:6px;padding:6px 10px;margin-top:6px;width:280px;max-width:90vw">
       <div id="lightboxAlsoIn" style="margin-top:8px;color:#ccc;font-size:12px;display:flex;flex-wrap:wrap;gap:5px;justify-content:center;align-items:center;max-width:90vw"></div>
+      <label id="lightboxHideRow" style="margin-top:8px;color:#ccc;font-size:12px;display:inline-flex;align-items:center;gap:6px;cursor:pointer">
+        <input type="checkbox" id="lightboxHideFromGallery" style="margin:0">
+        Hide from rotating gallery
+      </label>
       <div style="margin-top:8px;display:flex;gap:8px;justify-content:center;flex-wrap:wrap">
         <button id="lightboxPrev" class="ghost tiny" style="color:#fff;border-color:rgba(255,255,255,.2)">‹ Prev</button>
         <button id="lightboxNext" class="ghost tiny" style="color:#fff;border-color:rgba(255,255,255,.2)">Next ›</button>
@@ -1186,6 +1191,7 @@ function buildGalleryPool(){
     if (f.plantId && p.id !== f.plantId) continue;
     for (const ph of (p.photos||[])){
       if (!ph || !ph.key) continue;
+      if (ph.hideFromGallery) continue;   // honor per-photo "hide from gallery" toggle
       const d = ph.date || '';
       if (f.from && (!d || d < f.from)) continue;
       if (f.to && (!d || d > f.to)) continue;
@@ -1993,7 +1999,8 @@ function renderPhotos(p){
     const url = r2PublicUrl(ph.key);
     const dt = ph.date ? new Date(ph.date+'T12:00:00').toLocaleDateString(undefined,{month:'short',day:'numeric',year:'numeric'}) : '';
     const linkedBadge = ownKeys.has(ph.key) ? '' : '<div class="ph-linked" title="Linked from another plant">🔗</div>';
-    return `<div class="ph" data-idx="${idx}"><img loading="lazy" src="${url}" alt="${escapeHtml(ph.caption||'')}"><div class="date">${dt}</div>${linkedBadge}</div>`;
+    const hiddenBadge = ph.hideFromGallery ? '<div class="ph-hidden" title="Hidden from rotating gallery">🚫</div>' : '';
+    return `<div class="ph" data-idx="${idx}"><img loading="lazy" src="${url}" alt="${escapeHtml(ph.caption||'')}"><div class="date">${dt}</div>${linkedBadge}${hiddenBadge}</div>`;
   }).join('');
 }
 
@@ -2067,6 +2074,10 @@ function showLightboxIdx(){
   $('#lightboxImg').src = r2PublicUrl(ph.key);
   $('#lightboxDate').value = ph.date || '';
   $('#lightboxCaption').value = ph.caption || '';
+  // Read hideFromGallery off the canonical photo entry (so a linked-view
+  // shows the same state as the owner's view).
+  const { target } = getCanonicalPhoto(ph);
+  $('#lightboxHideFromGallery').checked = !!(target && target.hideFromGallery);
   renderLightboxAlsoIn(ph);
 }
 function renderLightboxAlsoIn(ph){
@@ -2142,6 +2153,17 @@ $('#lightboxDate').addEventListener('change', ()=>{
   if (!newDate) return;
   target.date = newDate;
   ph.date = newDate;
+  save();
+  const cur = state.plants.find(p => p.id === currentInfoPlantId);
+  if (cur) renderPhotos(cur);
+});
+$('#lightboxHideFromGallery').addEventListener('change', ()=>{
+  const ph = (state._lightboxPhotos||[])[lightboxIdx]; if (!ph) return;
+  const { target } = getCanonicalPhoto(ph);
+  if (!target) return;
+  if ($('#lightboxHideFromGallery').checked) target.hideFromGallery = true;
+  else delete target.hideFromGallery;
+  ph.hideFromGallery = target.hideFromGallery;
   save();
   const cur = state.plants.find(p => p.id === currentInfoPlantId);
   if (cur) renderPhotos(cur);


### PR DESCRIPTION
## Summary
Closes #55. Damage photos and other shots you don't want in the rotating hero gallery can now be hidden per-photo. They still appear in the plant's grid, timeline, and lightbox — only the front-page gallery strip skips them.

## UI
- **Lightbox**: new \"Hide from rotating gallery\" checkbox beneath the \"Also in\" chips. Toggles \`target.hideFromGallery\` on the canonical photo entry, so a linked-view shows the same state as the owner.
- **Photo grid**: small 🚫 badge in the top-left of any thumbnail that's currently hidden, so it's visible at a glance (matches the existing 🔗 badge for linked photos in the top-right).

## Plumbing
- New optional \`photo.hideFromGallery\` boolean (additive — schema stays clean by deleting the field when toggled off).
- \`buildGalleryPool()\` filters out photos with \`hideFromGallery === true\`.
- \`showLightboxIdx\` reads from the canonical photo when opening, so the checkbox always reflects truth (handles linked-view and multi-edit correctly).

## Test plan
- [ ] Open a photo's lightbox → \"Hide from rotating gallery\" checkbox appears.
- [ ] Toggle it on → the rotating gallery skips this photo on next refresh / pool rebuild.
- [ ] The plant's photo grid shows a 🚫 badge on the hidden photo.
- [ ] The plant's timeline scrubber and per-plant lightbox still include the photo.
- [ ] Toggle off → photo returns to the gallery rotation; badge disappears.
- [ ] If the photo is linked to multiple plants, hide is shared (set on owner, reflects everywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)