### PR TITLE
Dawn Redwood theme: green primary + rust contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,22 +55,22 @@
     --gradient-2:#ece5d0;
     --shadow:0 1px 2px rgba(0,0,0,.04), 0 8px 22px rgba(0,0,0,.08);
   }
-  /* Dawn Redwood — warm browns + rust accent + gold contrast */
+  /* Dawn Redwood — warm brown bg, fresh-foliage green primary, rust contrast */
   [data-theme="redwood"]{
     --bg:#1c1410;
     --bg2:#251c15;
     --panel:#2a2018;
     --panel2:#34291f;
-    --ink:#f0e2cc;
-    --ink-soft:#d2bb9b;
-    --muted:#9b8770;
+    --ink:#f0e6d0;
+    --ink-soft:#d2c0a0;
+    --muted:#9b8b75;
     --line:#3a2c20;
     --line2:#4d3b2c;
-    --accent:#d97a4a;        /* dawn redwood rust */
-    --accent-deep:#a85522;
-    --accent2:#f5c97a;       /* feathery foliage gold */
+    --accent:#95c468;        /* fresh dawn redwood foliage green */
+    --accent-deep:#6a9646;
+    --accent2:#d97a4a;       /* branch / autumn rust */
     --warn:#e08a4a;
-    --cool:#bd8d6a;
+    --cool:#bd8d6a;          /* warm bark */
     --chip:#34291f;
     --chip-line:#4d3b2c;
     --gradient-1:#3a2718;
@@ -1217,7 +1217,7 @@ const THEME_KEY = 'yardDashboard.theme';
 const THEMES = [
   { id:'dark',    label:'Teal Dark',     bg:'#08191c', accent:'#4dd0c1', meta:'#0d2629' },
   { id:'light',   label:'Cream Light',   bg:'#e6f1f2', accent:'#118a7d', meta:'#f3f9fa' },
-  { id:'redwood', label:'Dawn Redwood',  bg:'#1c1410', accent:'#d97a4a', meta:'#251c15' },
+  { id:'redwood', label:'Dawn Redwood',  bg:'#1c1410', accent:'#95c468', meta:'#251c15' },
   { id:'maple',   label:'Bloodgood Maple', bg:'#16080a', accent:'#d2554a', meta:'#1f0e10' },
   { id:'forest',  label:'Forest',        bg:'#0d1611', accent:'#8fc06a', meta:'#11201a' },
   { id:'slate',   label:'Slate Grey',    bg:'#13171b', accent:'#9aafc4', meta:'#1a1f24' },


### PR DESCRIPTION
## Summary
The Dawn Redwood theme was all warm tones (rust primary, gold contrast on brown bg). The user's reference photo shows the species' striking fresh-foliage green that wasn't represented.

Now: green is the **primary accent** (title, links, buttons, dominant pie slice), rust orange moves to **accent2** (still prominent in money chart bars, frost-damage pills, etc.), warm brown bg + bark-tone cool unchanged. Keeps both the green and the warm autumn feel.

## Test plan
- [ ] Pick Dawn Redwood theme → title \"Our Plants\" appears in fresh foliage green.
- [ ] Spend chart bars now green (accent), money chart bars now rust (accent2).
- [ ] Brown background + warm tones still dominate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)