### PR TITLE
Lightbox: photo flex-fits so controls always visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,13 +798,14 @@
 </div>
 
 <div class="modal-back" id="lightbox" style="background:rgba(0,0,0,.92);z-index:60">
-  <div style="position:relative;max-width:96vw;max-height:96vh;display:flex;flex-direction:column;align-items:center;gap:10px">
-    <button class="close" id="lightboxClose" style="position:absolute;top:-6px;right:-6px;color:#fff;font-size:28px">×</button>
-    <img id="lightboxImg" style="max-width:96vw;max-height:80vh;object-fit:contain;border-radius:8px;background:#0a0a0a">
-    <div id="lightboxMeta" style="color:#ddd;font-size:13px;text-align:center;max-width:96vw;padding:0 12px">
+  <div style="position:relative;width:96vw;max-width:96vw;height:96vh;max-height:96vh;display:flex;flex-direction:column;align-items:stretch;gap:10px;padding-top:32px">
+    <button class="close" id="lightboxClose" style="position:absolute;top:0;right:0;color:#fff;font-size:28px;background:rgba(0,0,0,.4);border-radius:50%;width:36px;height:36px;line-height:1;z-index:1">×</button>
+    <!-- Image fills remaining space; flex:1 + min-height:0 lets it shrink so the meta panel below always renders. -->
+    <img id="lightboxImg" style="flex:1 1 auto;min-height:0;width:100%;object-fit:contain;border-radius:8px;background:#0a0a0a">
+    <div id="lightboxMeta" style="flex:none;color:#ddd;font-size:13px;text-align:center;max-width:100%;padding:0 4px">
       <input type="date" id="lightboxDate" style="background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.2);color:#fff;border-radius:6px;padding:5px 10px;font-weight:600;text-align:center;color-scheme:dark">
       <input type="text" id="lightboxCaption" placeholder="add caption…" style="background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.2);color:#fff;border-radius:6px;padding:6px 10px;margin-top:6px;width:280px;max-width:90vw">
-      <div id="lightboxAlsoIn" style="margin-top:8px;color:#ccc;font-size:12px;display:flex;flex-wrap:wrap;gap:5px;justify-content:center;align-items:center;max-width:90vw"></div>
+      <div id="lightboxAlsoIn" style="margin-top:8px;color:#ccc;font-size:12px;display:flex;flex-wrap:wrap;gap:5px;justify-content:center;align-items:center;max-width:100%"></div>
       <label id="lightboxHideRow" style="margin-top:8px;color:#ccc;font-size:12px;display:inline-flex;align-items:center;gap:6px;cursor:pointer">
         <input type="checkbox" id="lightboxHideFromGallery" style="margin:0">
         Hide from rotating gallery


### PR DESCRIPTION
## Root cause
The lightbox image had \`max-height: 80vh\` and the meta panel below it (date input, caption input, also-in chips, hide checkbox, Prev/Next/Delete buttons) was free to overflow the viewport. On phones this pushed the buttons off-screen with no scroll bar to reach them.

## Fix
Restructured the inner container as a height-bounded flex column:
- Container: \`width: 96vw; height: 96vh; display: flex; flex-direction: column\`.
- Image: \`flex: 1 1 auto; min-height: 0; object-fit: contain\` — shrinks to leave room for the meta panel.
- Meta: \`flex: none\` — never shrinks, always rendered at natural size.

Side adjustments:
- Close × pulled inside the top-right padding (was hanging off the edge), with a circular dark bg so it's always tappable on busy photos.
- \`align-items: stretch\` so photo + meta share the full container width.
- \`padding-top: 32px\` reserves space for the close button.

## Test plan
- [ ] On phone (portrait): open any photo → all of date, caption, chips, checkbox, Prev/Next/Delete are visible without zooming or scrolling.
- [ ] On phone (landscape): same.
- [ ] On desktop: same; the photo just gets more breathing room.
- [ ] Tall portrait photo: scales to fit the available height.
- [ ] Wide landscape photo: scales to fit the available width; lots of black space top/bottom is fine.
- [ ] Close × is tappable in the top-right corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)