### PR TITLE
Add standard mobile-web-app-capable meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <meta name="theme-color" content="#0d1611">
+<meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="Plants">


### PR DESCRIPTION
## Summary
Apple deprecated \`apple-mobile-web-app-capable\` in iOS 17 in favor of the W3C standard \`mobile-web-app-capable\` (no \`apple-\` prefix). Both Chrome and Safari console-warn about the legacy form.

## Fix
Added the new tag alongside the old one. The old one stays for backward compatibility with iOS <17 home-screen installs.

## Test plan
- [ ] Refresh dashboard → console no longer shows the deprecation warning.
- [ ] iOS Add to Home Screen still launches in standalone (full-screen) mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)