### PR TITLE
Harden log merge against multi-tab overwrites

### DIFF
--- a/index.html
+++ b/index.html
@@ -1136,8 +1136,6 @@ if (!state.plants || !state.plants.length) state.plants = structuredClone(defaul
   }
   if (touched) saveLocal();
 })();
-console.log('[debug] LOAD: log entries with photoKeys =',
-  (state.log||[]).filter(e => Array.isArray(e.photoKeys) && e.photoKeys.length).map(e => ({id:e.id, photoKeys:e.photoKeys, modifiedAt:e.modifiedAt})));
 // Migration: when plants are renamed, orphaned plantIds in logs and
 // photo.alsoIn need remapping to the renamed plant. Three matching strategies,
 // in order of confidence:
@@ -3330,7 +3328,6 @@ $('#logEditSave').onclick = () => {
   // this edit. Merges (in pullFromRemote and pushWithRetry) prefer the side
   // with the larger modifiedAt for matching ids.
   e.modifiedAt = Date.now();
-  console.log('[debug] save: id=', e.id, 'photoKeys=', e.photoKeys, 'modifiedAt=', e.modifiedAt);
   $('#logEditModal').classList.remove('show');
   save(); render();
 };
@@ -3826,13 +3823,10 @@ async function pullFromSheet(){
       const nm = oldIdToName.get(oldId);
       return nm ? (newNameToId.get(nm) || null) : null;
     };
-    const beforeSheetMap = (state.log||[]).filter(e => Array.isArray(e.photoKeys) && e.photoKeys.length).length;
     state.log = (state.log||[]).map(e => {
       const newId = remap(e.plantId);
       return newId ? {...e, plantId:newId} : e;
     });
-    const afterSheetMap = (state.log||[]).filter(e => Array.isArray(e.photoKeys) && e.photoKeys.length).length;
-    console.log(`[debug] pullFromSheet log map: photoKeys entries before=${beforeSheetMap} after=${afterSheetMap}`);
     // Also remap photo cross-links (photo.alsoIn[]) on the existing plants —
     // do this BEFORE we replace state.plants so the carry-over plants keep
     // their links pointing at the new ids.
@@ -3950,20 +3944,29 @@ async function pullFromRemote(){
       const remoteIdSet = new Set((remote.data.plants||[]).map(p=>p.id));
       const localOnlyPlants = (state.plants||[]).filter(p => !remoteIdSet.has(p.id));
       state.plants = remote.data.plants ? [...mergedPlants, ...localOnlyPlants] : state.plants;
-      // Build merged log: for each remote entry, prefer whichever side has the
-      // more recent modifiedAt. Falls back to local when either side lacks the
-      // timestamp (legacy data) — which preserves the existing "local edits
-      // win" behavior for entries from before the timestamp existed.
+      // Build merged log: for each remote entry, pick the side with the more
+      // recent modifiedAt. Two extra protections against multi-tab races where
+      // a stale tab would otherwise overwrite a newer push:
+      //   1. If only remote has modifiedAt (le is pre-fix legacy), remote is
+      //      definitively newer — use remote regardless of how stale.
+      //   2. On a true tie (same or both-missing modifiedAt), prefer the side
+      //      with MORE photoKeys. Damage-photo links are additive; the side
+      //      with the longer array is almost always the correct one.
       const mergedRemoteLog = (remote.data.log||[]).map(re => {
         const le = localLogById.get(re.id);
         if (!le) return re;
         const lt = Number(le.modifiedAt) || 0;
         const rt = Number(re.modifiedAt) || 0;
-        return rt > lt ? re : le;
+        if (rt && !lt) return re;
+        if (rt > lt) return re;
+        if (lt > rt) return le;
+        // Tie — prefer the entry with more photoKeys (additive data tie-break)
+        const reN = Array.isArray(re.photoKeys) ? re.photoKeys.length : 0;
+        const leN = Array.isArray(le.photoKeys) ? le.photoKeys.length : 0;
+        if (reN > leN) return re;
+        return le;
       });
       state.log = [...mergedRemoteLog, ...localOnly];
-      console.log('[debug] pullFromRemote merged. With photoKeys after merge:',
-        state.log.filter(e => Array.isArray(e.photoKeys) && e.photoKeys.length).map(e => ({id:e.id, photoKeys:e.photoKeys, modifiedAt:e.modifiedAt})));
       const hadLocalPhotoPending = localPhotoPending.length > 0;
       const remoteSettings = remote.data.settings || {};
       state.settings = {...state.settings, ...remoteSettings};
@@ -4031,12 +4034,9 @@ async function pushWithRetry(triesLeft, useOptimistic = true){
   // even when nobody else is writing. Using lastSha bypasses the read-side cache.
   if (useOptimistic && lastSha){
     const blob = syncBlob();
-    console.log('[debug] pushWithRetry optimistic. Sending photoKeys:',
-      state.log.filter(e => Array.isArray(e.photoKeys) && e.photoKeys.length).map(e => ({id:e.id, photoKeys:e.photoKeys, modifiedAt:e.modifiedAt})));
     try {
       const newSha = await ghPut(blob, lastSha);
       lastSha = newSha;
-      console.log('[debug] pushWithRetry optimistic SUCCEEDED. lastSha=', lastSha);
       return;
     } catch(e){
       if (/\b409\b/.test(e.message) || /\b422\b/.test(e.message)){
@@ -4061,13 +4061,18 @@ async function pushWithRetry(triesLeft, useOptimistic = true){
       if (!re) return le;
       const lt = Number(le.modifiedAt) || 0;
       const rt = Number(re.modifiedAt) || 0;
-      return rt > lt ? re : le;
+      // Same multi-tab protections as pullFromRemote — see comments there.
+      if (rt && !lt) return re;
+      if (rt > lt) return re;
+      if (lt > rt) return le;
+      const reN = Array.isArray(re.photoKeys) ? re.photoKeys.length : 0;
+      const leN = Array.isArray(le.photoKeys) ? le.photoKeys.length : 0;
+      if (reN > leN) return re;
+      return le;
     });
     mergedLog = [...remoteOnly, ...localResolved];
   }
   state.log = mergedLog;
-  console.log('[debug] pushWithRetry pessimistic merged. With photoKeys:',
-    state.log.filter(e => Array.isArray(e.photoKeys) && e.photoKeys.length).map(e => ({id:e.id, photoKeys:e.photoKeys, modifiedAt:e.modifiedAt})));
   const blob = syncBlob();
   try {
     const newSha = await ghPut(blob, remote ? remote.sha : null);


### PR DESCRIPTION
## Summary
Confirmed cause of the disappearing photoKeys: a second tab/device with the dashboard open would auto-pull on its 60s cycle, fire \`setTimeout(pushNow, 200)\` from the post-pull \`hadLocalPending\` trigger, and overwrite the freshly-saved photoKeys via its optimistic PUT (its cached \`lastSha\` happened to match remote at that moment).

The user closed all other tabs and confirmed the issue stopped.

## Two extra protections (in both \`pullFromRemote\` and \`pushWithRetry\`'s pessimistic merge):

1. **Asymmetric modifiedAt** — if remote has \`modifiedAt\` but local doesn't, ALWAYS prefer remote. Local missing \`modifiedAt\` = pre-fix legacy state = provably older than any entry written under the new code. Stops a stale tab loaded before the modifiedAt fix from clobbering newer data.

2. **photoKeys-length tie-break** — on a true tie (same \`modifiedAt\` or both missing it), prefer the side with MORE photoKeys. Damage-photo links are additive; the side with the longer array is almost always the correct one. Edge case where user genuinely deleted photos before the tie: resolved by the \`modifiedAt\` bump fired by the deleting save.

## Cleanup
Removed the diagnostic \`console.log\` statements added in PR #80 to trace the issue. Their job is done.

## Test plan
- [ ] Refresh dashboard, attach photo to damage entry, save → thumb persists across multiple refreshes (single-tab).
- [ ] Open dashboard in two tabs. In Tab A, attach photo and save. In Tab B (stale), wait through an auto-pull cycle → Tab B's merge picks up the photoKeys from remote, push preserves them.
- [ ] Console no longer has \`[debug]\` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)