### PR TITLE
Reverse Dawn Redwood theme to light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,27 +56,27 @@
     --gradient-2:#ece5d0;
     --shadow:0 1px 2px rgba(0,0,0,.04), 0 8px 22px rgba(0,0,0,.08);
   }
-  /* Dawn Redwood — warm brown bg, fresh-foliage green primary, rust contrast */
+  /* Dawn Redwood — warm cream bg, fresh-foliage green primary, rust contrast */
   [data-theme="redwood"]{
-    --bg:#1c1410;
-    --bg2:#251c15;
-    --panel:#2a2018;
-    --panel2:#34291f;
-    --ink:#f0e6d0;
-    --ink-soft:#d2c0a0;
-    --muted:#9b8b75;
-    --line:#3a2c20;
-    --line2:#4d3b2c;
-    --accent:#95c468;        /* fresh dawn redwood foliage green */
-    --accent-deep:#6a9646;
-    --accent2:#d97a4a;       /* branch / autumn rust */
-    --warn:#e08a4a;
-    --cool:#bd8d6a;          /* warm bark */
-    --chip:#34291f;
-    --chip-line:#4d3b2c;
-    --gradient-1:#3a2718;
-    --gradient-2:#1f140d;
-    --shadow:0 1px 2px rgba(0,0,0,.4), 0 12px 36px rgba(0,0,0,.45);
+    --bg:#f0e6d0;
+    --bg2:#f7f0e2;
+    --panel:#fffaf2;
+    --panel2:#ede3d0;
+    --ink:#1c1410;
+    --ink-soft:#3a2c20;
+    --muted:#8b7a64;
+    --line:#d2c0a0;
+    --line2:#bd9f79;
+    --accent:#5a8a32;        /* fresh dawn redwood foliage green */
+    --accent-deep:#477226;
+    --accent2:#c06030;       /* branch / autumn rust */
+    --warn:#b86a28;
+    --cool:#9b7350;          /* warm bark */
+    --chip:#e8dcc6;
+    --chip-line:#d2c0a0;
+    --gradient-1:#e7dfc6;
+    --gradient-2:#f0e6d0;
+    --shadow:0 1px 2px rgba(0,0,0,.06), 0 8px 22px rgba(0,0,0,.10);
   }
   /* Slate — neutral cool grey, restrained accent */
   [data-theme="slate"]{


### PR DESCRIPTION
## Summary
- Inverts the Dawn Redwood theme from dark (brown bg / cream text) to light (cream bg / dark brown text)
- Keeps the same warm redwood palette — green foliage accent, rust contrast, bark tones
- Adjusted accent/shadow values for proper contrast on light backgrounds

## Test plan
- [ ] Switch to Dawn Redwood theme and verify cream background with dark text
- [ ] Check accent colors (green links, rust highlights) are readable on light bg
- [ ] Compare with Cream Light theme to ensure distinct identity
- [ ] Verify other themes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)